### PR TITLE
adding logrotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- this changelog
+- Enabled log rotation
 
 
 ## [v6.0.2-4] - 2023-04-26

--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -39,6 +39,10 @@ spec:
           subPath: suricata.yaml
         # args: ['-c', '/opt/suricata/suricata.yaml', "-i", "{{ .Values.interface }}"]
         args: ["-i", "{{ .Values.interface }}", "--set", "stream.memcap=16gb"]
+        lifecycle:
+          postStart:
+            exec:
+              command: ["logrotate", "-vf", "/etc/logrotate.d/suricata"]
       volumes:
       - name: logs
         hostPath:


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)

# Description

This change adds the command to enable Suricata log rotation using the default log rotation settings.

New dependencies added:
- None

# How Has This Been Tested?

Tested by deploying locally in K3D using dco-core's current main branch and this branch.


