### PR TITLE
sleep longer for t3's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+## [v7.0.0-2]
+### Updated
 - Upped lifecycle posthook command sleep time from 30 sec to 60 sec.
 
 ## [v7.0.0-1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Upped lifecycle posthook command sleep time from 30 sec to 60 sec.
 
 ## [v7.0.0-1]
 ### Added

--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -51,7 +51,7 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["/bin/sh", "-c", "sleep 30; logrotate -vf /etc/logrotate.d/suricata"]
+              command: ["/bin/sh", "-c", "sleep 60; logrotate -vf /etc/logrotate.d/suricata"]
       volumes:
       - name: logs
         hostPath:


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Description
T3's (much smaller machines) require suricata to sleep a tad longer in the postHook. Upped it from 30 sec to 60 sec.

Fixes # (issue)

# How Has This Been Tested?

Deployed zarf suricata package with updated sleep value on t1+t2+t3 cluster. All pods come up healthy.

**Test Configuration - Change as necessary**:
* Kubernetes version:
* Hardware:
* Capability:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added a plain language explanation of the changes to the Unreleased section of the CHANGELOG.md file

